### PR TITLE
fix: allow middle-click to open comments in new tab

### DIFF
--- a/src/app/components/story-item/story-item.html
+++ b/src/app/components/story-item/story-item.html
@@ -155,6 +155,7 @@
             <button
               type="button"
               (click)="openComments($event)"
+              (auxclick)="openComments($event)"
               (keyup.enter)="openComments($event)"
               (keyup.space)="openComments($event)"
               class="story-comments story-comments-trigger focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"

--- a/src/app/components/story-item/story-item.ts
+++ b/src/app/components/story-item/story-item.ts
@@ -418,7 +418,7 @@ export class StoryItem {
     return true;
   }
 
-  openComments(event: Event): void {
+  openComments(event: MouseEvent | KeyboardEvent): void {
     if (!this.story) return;
 
     if (!this.deviceService.isDesktop()) {
@@ -428,12 +428,13 @@ export class StoryItem {
       return;
     }
 
-    const isShiftClick = (event as MouseEvent).shiftKey;
-    const isCmdClick = (event as MouseEvent).metaKey;
-    const isCtrlClick = (event as MouseEvent).ctrlKey;
+    const isShiftClick = event instanceof MouseEvent && event.shiftKey;
+    const isCmdClick = event instanceof MouseEvent && event.metaKey;
+    const isCtrlClick = event instanceof MouseEvent && event.ctrlKey;
+    const isMiddleClick = event instanceof MouseEvent && event.button === 1;
 
-    if (isShiftClick || isCmdClick || isCtrlClick) {
-      // Open in new window if modifier key is pressed
+    if (isShiftClick || isCmdClick || isCtrlClick || isMiddleClick) {
+      // Open in new window if modifier key or middle mouse button is used
       // Use LocationStrategy to get the correct external URL with base href
       const path = this.locationStrategy.prepareExternalUrl(`/item/${this.story.id}`);
       const url = `${window.location.origin}${path}`;


### PR DESCRIPTION
## Summary
- allow middle mouse button to open comments by adding auxclick handler
- treat middle-click as new-tab request when opening comments

## Testing
- `npm run lint` *(fails: ng: not found)*
- `npm test` *(fails: ng: not found)*
- `npm run build:prod` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6cd6b0e4c8327a315859cdc0d1990