### PR TITLE
fix: scope PWA safe area adjustments

### DIFF
--- a/src/app/components/layout/header/header.component.ts
+++ b/src/app/components/layout/header/header.component.ts
@@ -69,6 +69,13 @@ import { HeaderMobileNavComponent } from './mobile-nav/header-mobile-nav.compone
         @apply bg-blue-600;
         @apply dark:bg-digg-blue;
       }
+
+      @media (display-mode: standalone) {
+        .app-header {
+          top: env(safe-area-inset-top, 0px);
+          padding-top: env(safe-area-inset-top, 0px);
+        }
+      }
     `,
   ],
 })

--- a/src/app/components/layout/header/header.component.ts
+++ b/src/app/components/layout/header/header.component.ts
@@ -72,8 +72,9 @@ import { HeaderMobileNavComponent } from './mobile-nav/header-mobile-nav.compone
 
       @media (display-mode: standalone) {
         .app-header {
-          top: env(safe-area-inset-top, 0px);
-          padding-top: env(safe-area-inset-top, 0px);
+          --safe-area-top: env(safe-area-inset-top, 0px);
+          top: var(--safe-area-top);
+          padding-top: var(--safe-area-top);
         }
       }
     `,

--- a/src/app/components/layout/offline-banner/offline-banner.component.ts
+++ b/src/app/components/layout/offline-banner/offline-banner.component.ts
@@ -34,8 +34,9 @@ import { CommonModule } from '@angular/common';
 
       @media (display-mode: standalone) {
         .offline-banner {
-          top: env(safe-area-inset-top, 0px);
-          padding-top: env(safe-area-inset-top, 0px);
+          --safe-area-top: env(safe-area-inset-top, 0px);
+          top: var(--safe-area-top);
+          padding-top: var(--safe-area-top);
         }
       }
 

--- a/src/app/components/layout/offline-banner/offline-banner.component.ts
+++ b/src/app/components/layout/offline-banner/offline-banner.component.ts
@@ -32,6 +32,13 @@ import { CommonModule } from '@angular/common';
         @apply fixed top-0 left-0 right-0 z-50 transition-all duration-300;
       }
 
+      @media (display-mode: standalone) {
+        .offline-banner {
+          top: env(safe-area-inset-top, 0px);
+          padding-top: env(safe-area-inset-top, 0px);
+        }
+      }
+
       .offline-banner-yellow {
         @apply bg-yellow-500 dark:bg-yellow-600;
       }

--- a/src/app/components/shared/scroll-to-top/scroll-to-top.component.ts
+++ b/src/app/components/shared/scroll-to-top/scroll-to-top.component.ts
@@ -42,6 +42,13 @@ import { ScrollService } from '../../../services/scroll.service';
       .scroll-to-top-btn:active > div {
         transform: scale(0.95);
       }
+
+      @media (display-mode: standalone) {
+        .scroll-to-top-btn {
+          inset-block-end: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);
+          inset-inline-start: calc(env(safe-area-inset-left, 0px) + 1.5rem);
+        }
+      }
     </style>
   `,
 })


### PR DESCRIPTION
## Summary
- pad the header and offline banner with safe-area insets so the PWA chrome no longer overlaps the notch
- offset the scroll-to-top control using safe-area inset values to keep it away from the home indicator
- scope the safe-area adjustments to standalone display mode so regular browser navigation remains unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2666848388327a5164d80604d768a